### PR TITLE
Replace Facebook with CovidSafe

### DIFF
--- a/ios/covidsafe.xcodeproj/project.pbxproj
+++ b/ios/covidsafe.xcodeproj/project.pbxproj
@@ -423,7 +423,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastUpgradeCheck = 940;
-				ORGANIZATIONNAME = Facebook;
+				ORGANIZATIONNAME = CovidSafe;
 				TargetAttributes = {
 					00E356ED1AD99517003FC87E = {
 						CreatedOnToolsVersion = 6.2;

--- a/ios/covidsafe/AppDelegate.h
+++ b/ios/covidsafe/AppDelegate.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) CovidSafe, Inc. and its affiliates.
+ * Copyright (c) CovidSafe.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
@@ -10,6 +10,6 @@
 
 @interface AppDelegate : UIResponder <UIApplicationDelegate, RCTBridgeDelegate>
 
-@property (nonatomic, strong) UIWindow *window;
+@property(nonatomic, strong) UIWindow *window;
 
 @end

--- a/ios/covidsafe/AppDelegate.h
+++ b/ios/covidsafe/AppDelegate.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) CovidSafe, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/ios/covidsafe/AppDelegate.m
+++ b/ios/covidsafe/AppDelegate.m
@@ -22,7 +22,7 @@
                                                    moduleName:@"covidsafe"
                                             initialProperties:nil];
 
-  rootView.backgroundColor = [[UIColor alloc] initWithRed:1.0f green:1.0f blue:1.0f alpha:1];
+  rootView.backgroundColor = [UIColor whiteColor];
 
   self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
   UIViewController *rootViewController = [UIViewController new];

--- a/ios/covidsafe/AppDelegate.m
+++ b/ios/covidsafe/AppDelegate.m
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) CovidSafe, Inc. and its affiliates.
+ * Copyright (c) CovidSafe.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/ios/covidsafe/AppDelegate.m
+++ b/ios/covidsafe/AppDelegate.m
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) CovidSafe, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/ios/covidsafe/main.m
+++ b/ios/covidsafe/main.m
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) CovidSafe, Inc. and its affiliates.
+ * Copyright (c) CovidSafe.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/ios/covidsafe/main.m
+++ b/ios/covidsafe/main.m
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) CovidSafe, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/ios/covidsafeTests/covidsafeTests.m
+++ b/ios/covidsafeTests/covidsafeTests.m
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) CovidSafe, Inc. and its affiliates.
+ * Copyright (c) CovidSafe.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/ios/covidsafeTests/covidsafeTests.m
+++ b/ios/covidsafeTests/covidsafeTests.m
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) CovidSafe, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
@@ -59,7 +59,7 @@
       return NO;
     }];
   }
-  
+
 #ifdef DEBUG
   RCTSetLogFunction(RCTDefaultLogFunction);
 #endif


### PR DESCRIPTION
- Use default white color instead of reconstructing it
- Replace default Facebook with current project name CovidSafe