### PR TITLE
[Contact Log] [Locations UI] Add spacing between time periods

### DIFF
--- a/ContactLog/Locations.js
+++ b/ContactLog/Locations.js
@@ -55,12 +55,16 @@ class Locations extends Component {
         {this.state.addresses.map((address, idx) => {
           const name = address[0] === '' ? 'Unknown Location' : address[0];
           const timePeriods = address[2].split(',');
-          const tsStringList = timePeriods.map(timePeriod => {
-            const tsList = timePeriod.split('-');
-            const start = DateConverter.timeString(parseInt(tsList[0].trim()));
-            const end = DateConverter.timeString(parseInt(tsList[1].trim()));
-            return `${start}-${end}`;
-          });
+          const format = time =>
+            DateConverter.timeString(parseInt(time.trim(), 10));
+          const tsStringList = timePeriods
+            .map(timePeriod => {
+              const tsList = timePeriod.split('-');
+              const start = format(tsList[0]);
+              const end = format(tsList[1]);
+              return `${start}-${end}`;
+            })
+            .join('  ');
           return (
             <View style={styles.address_card} key={idx}>
               {address[0] !== '' && <Text style={styles.name}>{name}</Text>}


### PR DESCRIPTION
Previously it looks like 
```
1:23 AM-2:34 PM3:45 PM-4:56 PM
```
where the earlier period end time is adjacent to the start time of the later time period without any spacing. This PR changes it to look like:

```
1:23 AM-2:34 PM  3:45 PM-4:56 PM
```