### PR TITLE
Ignore Warnings from Dependencies

### DIFF
--- a/ios/Podfile
+++ b/ios/Podfile
@@ -1,5 +1,6 @@
 platform :ios, '9.0'
 require_relative '../node_modules/@react-native-community/cli-platform-ios/native_modules'
+inhibit_all_warnings!
 
 target 'covidsafe' do
   # Pods for covidsafe


### PR DESCRIPTION
These build warnings are not really useful as we don't control/manage/modify/... our dependencies.