### PR TITLE
Pin react-native-vector-icons to 6.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "react-native-securerandom": "^1.0.0",
     "react-native-share": "^3.6.0",
     "react-native-splash-screen": "^3.2.0",
-    "react-native-vector-icons": "^6.6.0",
+    "react-native-vector-icons": "6.6.0",
     "react-native-webview": "^10.3.1",
     "react-native-xml2js": "^1.0.3",
     "react-redux": "^6.0.0",


### PR DESCRIPTION
This is a workaround for this (hopefully temporary) issue:
https://github.com/oblador/react-native-vector-icons/issues/1193